### PR TITLE
Provide vararg UnionOfRows/UnionOfColumns

### DIFF
--- a/LinearAlgebraForCAP/Project.toml
+++ b/LinearAlgebraForCAP/Project.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 
 # Transpiled from GAP's LinearAlgebraForCAP v2025.07-03
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 MatricesForHomalg = "29b9b1b6-efa6-450e-8188-a5a2c25df071"

--- a/LinearAlgebraForCAP/src/pre_init.jl
+++ b/LinearAlgebraForCAP/src/pre_init.jl
@@ -59,6 +59,17 @@ function ConvertColumnToMatrix( mat::MatricesForHomalg.TypeOfMatrixForHomalg, r:
 	
 end
 
+import MatricesForHomalg.UnionOfRows
+import MatricesForHomalg.UnionOfColumns
+
+function UnionOfRows(list::MatricesForHomalg.TypeOfMatrixForHomalg...)::MatricesForHomalg.TypeOfMatrixForHomalg
+  UnionOfRows(HomalgRing(list[1]), NrCols(list[1]), list)
+end
+
+function UnionOfColumns(list::MatricesForHomalg.TypeOfMatrixForHomalg...)::MatricesForHomalg.TypeOfMatrixForHomalg
+  UnionOfColumns(HomalgRing(list[1]), NrRows(list[1]), list)
+end
+
 function EntriesOfHomalgMatrix( mat::MatricesForHomalg.TypeOfMatrixForHomalg )
 	vcat(EntriesOfHomalgMatrixAsListList(mat)...)
 end


### PR DESCRIPTION
Import MatricesForHomalg.UnionOfRows/UnionOfColumns and add vararg overloads that infer ring and dimensions from the first matrix. This simplifies constructing unions of rows/columns.

Bump version of LinearAlgebraForCAP to V0.1.11